### PR TITLE
fix(base64): write 3rd output char when 2-byte tail is encoded  b64_encode() skipped the third Base-64 character for a 2-byte remainder, producing a 3-char fragment like “xx=” instead of the required “xxx=”.  The fix inserts the missing lookup:      *dst = charTable[(src[1] & 0x0F) << 2];  Now the encoder returns the correct length and value for any input size (e.g. 20-byte buffer → “Vjy0J37I94IalsBBNhhYxQf82jY=”).

### DIFF
--- a/base64.c
+++ b/base64.c
@@ -47,14 +47,17 @@ void b64_encode(uint8_t *src, size_t len, uint8_t *dst)
 		len -= 3;
 	}
 
-	if(len == 2)
-	{
-		// 1st & 2nd b64char
-		b64_encodeFirstByte(src, dst);
-		dst += 2;
+	if (len == 2) {
+    	/* 1st & 2nd chars */
+    	b64_encodeFirstByte(src, dst);
+    	dst += 2;
 
-		// padding
-		*dst = '=';
+    	/* 3rd char — top 4 bits of the second byte */
+    	*dst = charTable[(src[1] & 0x0F) << 2];
+    	dst++;
+
+    	/* padding */
+    	*dst = '=';
 	}
 	else if(len == 1)
 	{


### PR DESCRIPTION
### What & why
b64_encode() produced an invalid Base-64 string whenever the input
ended with exactly two bytes: the third encoded character was omitted,
resulting in “xx=” instead of “xxx=”.  Decoders accept the padding but
drop the last 6 bits, so round-tripping loses data.

Example failure:

input : 56 3c b4 27 7e c8 f7 82 1a 96 c0 41 36 18 58 c5 07 fc da 36
expected: Vjy0J37I94IalsBBNhhYxQf82jY=
current : Vjy0J37I94IalsBBNhhYxQf82j=

### Fix
Add the missing third character for the 2-byte tail:

```c
/* 3rd char */
*dst = charTable[(src[1] & 0x0F) << 2];
dst++;